### PR TITLE
Fix QtBinding Issue for Marvelous Designer 2026.x

### DIFF
--- a/client/ayon_marvelousdesigner/hooks/pre_install_pyside.py
+++ b/client/ayon_marvelousdesigner/hooks/pre_install_pyside.py
@@ -6,15 +6,28 @@ This module provides:
 """
 from __future__ import annotations
 
+import json
 import platform
+import shutil
 import subprocess
 import sys
+import tempfile
+import urllib.request
 import zipfile
 from pathlib import Path
 from typing import ClassVar, Union
 
 from ayon_applications import LaunchTypes, PreLaunchHook
-from ayon_marvelousdesigner import MARVELOUS_DESIGNER_HOST_DIR
+
+# PySide6 wheels to download from PyPI for Windows (cp39 abi3 win_amd64).
+# Must stay in dependency order: shiboken6 first, then PySide6 core.
+_PYSIDE6_VERSION = "6.10.1"
+_PYSIDE6_WHEELS = [
+    ("shiboken6", "shiboken6-6.10.1-cp39-abi3-win_amd64.whl"),
+    ("PySide6", "pyside6-6.10.1-cp39-abi3-win_amd64.whl"),
+    ("PySide6-Essentials", "pyside6_essentials-6.10.1-cp39-abi3-win_amd64.whl"),
+    ("PySide6-Addons", "pyside6_addons-6.10.1-cp39-abi3-win_amd64.whl"),
+]
 
 
 class InstallQtBinding(PreLaunchHook):
@@ -122,24 +135,62 @@ class InstallQtBinding(PreLaunchHook):
         return None
 
     def extract_wheels(self, qt_binding_dir: Path) -> bool:
-        """Extract wheel files in the specified directory.
+        """Download PySide6 wheels from PyPI to a temp dir and extract them.
 
         Args:
-            qt_binding_dir (Path): The directory containing the wheel files
-                to extract.
+            qt_binding_dir (Path): The directory to extract wheel contents
+                into.
 
         Returns:
-            bool: True if extraction was successful, False otherwise.
+            bool: True if all wheels were downloaded and extracted
+                successfully, False otherwise.
 
         """
-        wheel_dir = Path(MARVELOUS_DESIGNER_HOST_DIR) / "wheels"
+        tmp_dir = Path(tempfile.mkdtemp(prefix="ayon_pyside6_"))
         try:
-            for wheel_file in wheel_dir.glob("*.whl"):
-                with zipfile.ZipFile(wheel_file, "r") as zip_ref:
+            for package, wheel_filename in _PYSIDE6_WHEELS:
+                self.log.info("Downloading %s ...", wheel_filename)
+                wheel_path = self._download_wheel_from_pypi(
+                    package, _PYSIDE6_VERSION, wheel_filename, tmp_dir
+                )
+                with zipfile.ZipFile(wheel_path, "r") as zip_ref:
                     zip_ref.extractall(qt_binding_dir)
-
+                self.log.info("Extracted %s", wheel_filename)
         except Exception as error:
             self.log.warning(
-                'Failed to extract wheel files: "%s".', error, exc_info=True)
+                'Failed to download/extract wheels: "%s".', error,
+                exc_info=True)
             return False
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
         return True
+
+    @staticmethod
+    def _download_wheel_from_pypi(
+            package: str, version: str,
+            wheel_filename: str, dest_dir: Path) -> Path:
+        """Download a specific wheel from PyPI using the JSON API.
+
+        Args:
+            package (str): PyPI package name.
+            version: Exact version string.
+            wheel_filename: Expected wheel filename to locate in the release.
+            dest_dir: Directory to save the downloaded wheel.
+
+        Returns:
+            Path: Path to the downloaded wheel file.
+
+        """  # noqa: DOC501
+        api_url = f"https://pypi.org/pypi/{package}/{version}/json"
+        with urllib.request.urlopen(api_url, timeout=60) as resp:
+            data = json.loads(resp.read())
+        for url_info in data.get("urls", []):
+            if url_info["filename"] == wheel_filename:
+                dest = dest_dir / wheel_filename
+                urllib.request.urlretrieve(url_info["url"], dest)  # noqa: S310
+                return dest
+        msg = (
+            f"Wheel '{wheel_filename}' not found for "
+            f"{package}=={version} on PyPI"
+        )
+        raise FileNotFoundError(msg)

--- a/client/ayon_marvelousdesigner/hooks/pre_install_pyside.py
+++ b/client/ayon_marvelousdesigner/hooks/pre_install_pyside.py
@@ -7,10 +7,8 @@ This module provides:
 from __future__ import annotations
 
 import json
-import platform
 import shutil
 import subprocess
-import sys
 import tempfile
 import urllib.request
 import zipfile
@@ -23,10 +21,10 @@ from ayon_applications import LaunchTypes, PreLaunchHook
 # Must stay in dependency order: shiboken6 first, then PySide6 core.
 _PYSIDE6_VERSION = "6.10.1"
 _PYSIDE6_WHEELS = [
-    ("shiboken6", "shiboken6-6.10.1-cp39-abi3-win_amd64.whl"),
-    ("PySide6", "pyside6-6.10.1-cp39-abi3-win_amd64.whl"),
-    ("PySide6-Essentials", "pyside6_essentials-6.10.1-cp39-abi3-win_amd64.whl"),  # noqa: E501
-    ("PySide6-Addons", "pyside6_addons-6.10.1-cp39-abi3-win_amd64.whl"),
+    ("shiboken6", f"shiboken6-{_PYSIDE6_VERSION}-cp39-abi3-win_amd64.whl"),
+    ("PySide6", f"pyside6-{_PYSIDE6_VERSION}-cp39-abi3-win_amd64.whl"),
+    ("PySide6-Essentials", f"pyside6_essentials-{_PYSIDE6_VERSION}-cp39-abi3-win_amd64.whl"),  # noqa: E501
+    ("PySide6-Addons", f"pyside6_addons-{_PYSIDE6_VERSION}-cp39-abi3-win_amd64.whl"),       # noqa: E501
 ]
 
 
@@ -39,7 +37,6 @@ class InstallQtBinding(PreLaunchHook):
 
     def execute(self) -> None:
         """Execute the pre-launch hook to install PySide6."""
-        current_platform = platform.system().lower()
         md_setting = self.data["project_settings"]["marvelous_designer"]
         qt_binding_dir = md_setting["prelaunch_settings"].get(
             "qt_binding_dir", "")
@@ -49,10 +46,8 @@ class InstallQtBinding(PreLaunchHook):
                 "Qt binding directory '%s' does not exist.", qt_binding_dir
             )
             return
-        if current_platform != "windows":
-            return_code = self.install_pyside(sys.executable, qt_binding_dir)
-        else:
-            return_code = self.extract_wheels(qt_binding_dir)
+
+        return_code = self.extract_wheels(qt_binding_dir)
         if return_code:
             self.log.info("PySide6 installed successfully.")
             self.launch_context.env["QtDir"] = qt_binding_dir.as_posix()
@@ -89,7 +84,7 @@ class InstallQtBinding(PreLaunchHook):
             "install",
             # we need to specify exact version of PySide6 to make sure
             # it is binary compatible with Marvelous Designer's python version
-            "PySide6==6.10.1",
+            f"PySide6=={_PYSIDE6_VERSION}",
             "--target",
             qt_binding_dir.as_posix(),
             "--ignore-installed",

--- a/client/ayon_marvelousdesigner/hooks/pre_install_pyside.py
+++ b/client/ayon_marvelousdesigner/hooks/pre_install_pyside.py
@@ -151,8 +151,8 @@ class InstallQtBinding(PreLaunchHook):
             for package, wheel_filename in _PYSIDE6_WHEELS:
                 if (qt_binding_dir / wheel_filename).exists():
                     self.log.info(
-                        "Wheel '%s' already exists, skipping download.",
-                        wheel_filename
+                        "Wheel '%s' already exists in %s, skipping download.",
+                        wheel_filename, qt_binding_dir
                     )
                     continue
                 self.log.info("Downloading %s ...", wheel_filename)

--- a/client/ayon_marvelousdesigner/hooks/pre_install_pyside.py
+++ b/client/ayon_marvelousdesigner/hooks/pre_install_pyside.py
@@ -7,12 +7,14 @@ This module provides:
 from __future__ import annotations
 
 import platform
-import shutil
 import subprocess
+import sys
+import zipfile
 from pathlib import Path
 from typing import ClassVar, Union
 
 from ayon_applications import LaunchTypes, PreLaunchHook
+from ayon_marvelousdesigner import MARVELOUS_DESIGNER_HOST_DIR
 
 
 class InstallQtBinding(PreLaunchHook):
@@ -25,12 +27,6 @@ class InstallQtBinding(PreLaunchHook):
     def execute(self) -> None:
         """Execute the pre-launch hook to install PySide6."""
         current_platform = platform.system().lower()
-        python_exe = (
-            "python"
-            if current_platform != "windows"
-            else "python.exe"
-        )
-        python_executable = Path(shutil.which(python_exe)).as_posix()
         md_setting = self.data["project_settings"]["marvelous_designer"]
         qt_binding_dir = md_setting["prelaunch_settings"].get(
             "qt_binding_dir", "")
@@ -40,11 +36,17 @@ class InstallQtBinding(PreLaunchHook):
                 "Qt binding directory '%s' does not exist.", qt_binding_dir
             )
             return
-
-        return_code = self.install_pyside(python_executable, qt_binding_dir)
+        if current_platform != "windows":
+            return_code = self.install_pyside(sys.executable, qt_binding_dir)
+        else:
+            return_code = self.extract_wheels(qt_binding_dir)
         if return_code:
             self.log.info("PySide6 installed successfully.")
             self.launch_context.env["QtDir"] = qt_binding_dir.as_posix()
+            plugin_dir = qt_binding_dir / "PySide6" / "plugins"
+            self.launch_context.env["QT_PLUGIN_PATH"] = (
+                plugin_dir.as_posix()
+            )
 
     def install_pyside(
             self, python_executable: str,
@@ -72,7 +74,9 @@ class InstallQtBinding(PreLaunchHook):
             "-m",
             "pip",
             "install",
-            "PySide6",
+            # we need to specify exact version of PySide6 to make sure
+            # it is binary compatible with Marvelous Designer's python version
+            "PySide6==6.10.1",
             "--target",
             qt_binding_dir.as_posix(),
             "--ignore-installed",
@@ -116,3 +120,26 @@ class InstallQtBinding(PreLaunchHook):
             return process.returncode == 0
 
         return None
+
+    def extract_wheels(self, qt_binding_dir: Path) -> bool:
+        """Extract wheel files in the specified directory.
+
+        Args:
+            qt_binding_dir (Path): The directory containing the wheel files
+                to extract.
+
+        Returns:
+            bool: True if extraction was successful, False otherwise.
+
+        """
+        wheel_dir = Path(MARVELOUS_DESIGNER_HOST_DIR) / "wheels"
+        try:
+            for wheel_file in wheel_dir.glob("*.whl"):
+                with zipfile.ZipFile(wheel_file, "r") as zip_ref:
+                    zip_ref.extractall(qt_binding_dir)
+
+        except Exception as error:
+            self.log.warning(
+                'Failed to extract wheel files: "%s".', error, exc_info=True)
+            return False
+        return True

--- a/client/ayon_marvelousdesigner/hooks/pre_install_pyside.py
+++ b/client/ayon_marvelousdesigner/hooks/pre_install_pyside.py
@@ -149,6 +149,12 @@ class InstallQtBinding(PreLaunchHook):
         tmp_dir = Path(tempfile.mkdtemp(prefix="ayon_pyside6_"))
         try:
             for package, wheel_filename in _PYSIDE6_WHEELS:
+                if (qt_binding_dir / wheel_filename).exists():
+                    self.log.info(
+                        "Wheel '%s' already exists, skipping download.",
+                        wheel_filename
+                    )
+                    continue
                 self.log.info("Downloading %s ...", wheel_filename)
                 wheel_path = self._download_wheel_from_pypi(
                     package, _PYSIDE6_VERSION, wheel_filename, tmp_dir

--- a/client/ayon_marvelousdesigner/hooks/pre_install_pyside.py
+++ b/client/ayon_marvelousdesigner/hooks/pre_install_pyside.py
@@ -25,7 +25,7 @@ _PYSIDE6_VERSION = "6.10.1"
 _PYSIDE6_WHEELS = [
     ("shiboken6", "shiboken6-6.10.1-cp39-abi3-win_amd64.whl"),
     ("PySide6", "pyside6-6.10.1-cp39-abi3-win_amd64.whl"),
-    ("PySide6-Essentials", "pyside6_essentials-6.10.1-cp39-abi3-win_amd64.whl"),
+    ("PySide6-Essentials", "pyside6_essentials-6.10.1-cp39-abi3-win_amd64.whl"),  # noqa: E501
     ("PySide6-Addons", "pyside6_addons-6.10.1-cp39-abi3-win_amd64.whl"),
 ]
 

--- a/client/ayon_marvelousdesigner/hooks/pre_install_pyside.py
+++ b/client/ayon_marvelousdesigner/hooks/pre_install_pyside.py
@@ -1,14 +1,16 @@
 """Pre-launch hook for installing Qt bindings in Marvelous Designer.
 
 This module provides:
-- InstallQtBinding: Pre-launch hook that installs PySide6 to MD's
+InstallQtBinding: Pre-launch hook that installs PySide6 to MD's
   Python environment to enable Qt-based functionality.
 """
 from __future__ import annotations
 
 import json
+import platform
 import shutil
 import subprocess
+import sys
 import tempfile
 import urllib.request
 import zipfile
@@ -17,14 +19,14 @@ from typing import ClassVar, Union
 
 from ayon_applications import LaunchTypes, PreLaunchHook
 
-# PySide6 wheels to download from PyPI for Windows (cp39 abi3 win_amd64).
+# PySide6 packages to download from PyPI.
 # Must stay in dependency order: shiboken6 first, then PySide6 core.
 _PYSIDE6_VERSION = "6.10.1"
-_PYSIDE6_WHEELS = [
-    ("shiboken6", f"shiboken6-{_PYSIDE6_VERSION}-cp39-abi3-win_amd64.whl"),
-    ("PySide6", f"pyside6-{_PYSIDE6_VERSION}-cp39-abi3-win_amd64.whl"),
-    ("PySide6-Essentials", f"pyside6_essentials-{_PYSIDE6_VERSION}-cp39-abi3-win_amd64.whl"),  # noqa: E501
-    ("PySide6-Addons", f"pyside6_addons-{_PYSIDE6_VERSION}-cp39-abi3-win_amd64.whl"),       # noqa: E501
+_PYSIDE6_PACKAGES = [
+    "shiboken6",
+    "PySide6",
+    "PySide6-Essentials",
+    "PySide6-Addons",
 ]
 
 
@@ -143,16 +145,10 @@ class InstallQtBinding(PreLaunchHook):
         """
         tmp_dir = Path(tempfile.mkdtemp(prefix="ayon_pyside6_"))
         try:
-            for package, wheel_filename in _PYSIDE6_WHEELS:
-                if (qt_binding_dir / wheel_filename).exists():
-                    self.log.info(
-                        "Wheel '%s' already exists in %s, skipping download.",
-                        wheel_filename, qt_binding_dir
-                    )
-                    continue
-                self.log.info("Downloading %s ...", wheel_filename)
-                wheel_path = self._download_wheel_from_pypi(
-                    package, _PYSIDE6_VERSION, wheel_filename, tmp_dir
+            for package in _PYSIDE6_PACKAGES:
+                self.log.info("Resolving compatible wheel for %s ...", package)
+                wheel_path, wheel_filename = self._download_wheel_from_pypi(
+                    package, _PYSIDE6_VERSION, tmp_dir
                 )
                 with zipfile.ZipFile(wheel_path, "r") as zip_ref:
                     zip_ref.extractall(qt_binding_dir)
@@ -169,29 +165,112 @@ class InstallQtBinding(PreLaunchHook):
     @staticmethod
     def _download_wheel_from_pypi(
             package: str, version: str,
-            wheel_filename: str, dest_dir: Path) -> Path:
-        """Download a specific wheel from PyPI using the JSON API.
+            dest_dir: Path) -> tuple[Path, str]:
+        """Download a compatible wheel from PyPI using the JSON API.
 
         Args:
             package (str): PyPI package name.
             version: Exact version string.
-            wheel_filename: Expected wheel filename to locate in the release.
             dest_dir: Directory to save the downloaded wheel.
 
         Returns:
-            Path: Path to the downloaded wheel file.
+            tuple[Path, str]: Downloaded wheel path and wheel filename.
 
-        """  # noqa: DOC501
+        """
         api_url = f"https://pypi.org/pypi/{package}/{version}/json"
         with urllib.request.urlopen(api_url, timeout=60) as resp:
             data = json.loads(resp.read())
-        for url_info in data.get("urls", []):
-            if url_info["filename"] == wheel_filename:
-                dest = dest_dir / wheel_filename
-                urllib.request.urlretrieve(url_info["url"], dest)  # noqa: S310
-                return dest
-        msg = (
-            f"Wheel '{wheel_filename}' not found for "
-            f"{package}=={version} on PyPI"
+        wheel_url_info = InstallQtBinding._select_compatible_wheel_url(
+            package, version, data.get("urls", [])
         )
-        raise FileNotFoundError(msg)
+        wheel_filename = wheel_url_info["filename"]
+        dest = dest_dir / wheel_filename
+        urllib.request.urlretrieve(wheel_url_info["url"], dest)  # noqa: S310
+        return dest, wheel_filename
+
+    @staticmethod
+    def _select_compatible_wheel_url(
+            package: str, version: str, urls: list[dict]) -> dict:
+        """Pick the best matching wheel entry for the current OS/arch.
+
+        Args:
+            package: PyPI package name.
+            version: Exact version string.
+            urls: List of URL info dicts from PyPI JSON API.
+
+        Returns:
+            dict: The URL info dict for the best matching wheel.
+
+        Raises:
+            FileNotFoundError: If no compatible wheel is found.
+        """
+        normalized_package = package.lower().replace("-", "_")
+        prefix = f"{normalized_package}-{version}-cp39-abi3-"
+
+        candidates = [
+            url_info
+            for url_info in urls
+            if url_info.get("packagetype") == "bdist_wheel"
+            and url_info.get("filename", "").lower().startswith(prefix)
+        ]
+
+        if not candidates:
+            msg = (
+                f"No cp39-abi3 wheel candidates found for "
+                f"{package}=={version} on PyPI"
+            )
+            raise FileNotFoundError(msg)
+
+        platform_key = sys.platform
+        machine = platform.machine().lower()
+
+        preferred_tags = InstallQtBinding._preferred_tags(
+            platform_key, machine
+        )
+
+        def _score(filename: str) -> int:
+            lowered = filename.lower()
+            score = 0
+            for tag in preferred_tags:
+                if tag in lowered:
+                    score += 1
+            return score
+
+        best = max(
+            candidates,
+            key=lambda url_info: _score(url_info["filename"]),
+        )
+        if _score(best["filename"]) == 0:
+            available = ", ".join(
+                url_info["filename"] for url_info in candidates
+            )
+            msg = (
+                f"No compatible wheel found for {package}=={version} on "
+                f"platform={platform_key}, arch={machine}. "
+                f"Available: {available}"
+            )
+            raise FileNotFoundError(msg)
+
+        return best
+
+    @staticmethod
+    def _preferred_tags(platform_key: str, machine: str) -> list[str]:
+        """Return tag preferences for selecting a platform-specific wheel.
+
+        Raises:
+            RuntimeError: If the platform is unsupported.
+
+        """
+        if platform_key.startswith("win"):
+            return ["win_amd64"]
+        if platform_key.startswith("linux"):
+            if machine in {"aarch64", "arm64"}:
+                return ["manylinux", "aarch64", "arm64"]
+            return ["manylinux", "x86_64", "amd64"]
+        if platform_key == "darwin":
+            if machine in {"arm64", "aarch64"}:
+                return ["macosx", "universal2", "arm64"]
+            return ["macosx", "universal2", "x86_64"]
+
+        msg = f"Unsupported platform for wheel selection: {platform_key}"
+        raise RuntimeError(msg)

--- a/client/ayon_marvelousdesigner/hooks/pre_install_pyside.py
+++ b/client/ayon_marvelousdesigner/hooks/pre_install_pyside.py
@@ -146,6 +146,16 @@ class InstallQtBinding(PreLaunchHook):
         tmp_dir = Path(tempfile.mkdtemp(prefix="ayon_pyside6_"))
         try:
             for package in _PYSIDE6_PACKAGES:
+                if self._is_package_extracted(
+                    qt_binding_dir, package, _PYSIDE6_VERSION
+                ):
+                    self.log.info(
+                        "%s==%s already extracted, skipping.",
+                        package,
+                        _PYSIDE6_VERSION,
+                    )
+                    continue
+
                 self.log.info("Resolving compatible wheel for %s ...", package)
                 wheel_path, wheel_filename = self._download_wheel_from_pypi(
                     package, _PYSIDE6_VERSION, tmp_dir
@@ -161,6 +171,29 @@ class InstallQtBinding(PreLaunchHook):
         finally:
             shutil.rmtree(tmp_dir, ignore_errors=True)
         return True
+
+    @staticmethod
+    def _is_package_extracted(
+            qt_binding_dir: Path, package: str, version: str) -> bool:
+        """Return whether a package/version appears to already be extracted.
+
+        Args:
+            qt_binding_dir(Path): Directory where the package is extracted.
+            package (str): PyPI package name.
+            version (str): Exact version string.
+
+        Returns:
+            bool: True if the package appears to be already extracted,
+                False otherwise.
+        """
+        normalized = package.lower().replace("-", "_")
+        dist_info_name = f"{normalized}-{version}.dist-info"
+
+        for path in qt_binding_dir.glob("*.dist-info"):
+            if path.name.lower() == dist_info_name:
+                return True
+
+        return False
 
     @staticmethod
     def _download_wheel_from_pypi(


### PR DESCRIPTION
## Changelog Description
This PR is to hot fix the qt binding issue for the latest version of Marvelous Designer 2026.x
Resolve https://github.com/ynput/ayon-marvelous-designer/issues/17

## Additional review information
- We need to consider if we should find the Qt version for the code. But it would make things complicated.
I used this script to find the version of Qt for MD(for windows only as it is using powershell)
```python
import ctypes
import os
import sys

# Try to find Qt6Core.dll in the same directory as the executable
md_dir = os.path.dirname(sys.executable)
qt_core_path = os.path.join(md_dir, "Qt6Core.dll")
if os.path.exists(qt_core_path):
    # Use Windows API to get file version
    import subprocess
    result = subprocess.run(['powershell', '-Command', f"(Get-Item '{qt_core_path}').VersionInfo.ProductVersion"], capture_output=True, text=True)
    print(f"Marvelous Designer Qt version: {result.stdout.strip()}")
else:
    print("Could not locate Qt6Core.dll")
```
But there is different approach to find the exact version for Qt across the platform
- We need to think the better solutions to get the PySide6 installation, as so far this case of storing wheels is not really innovative.
- I am thinking of using virtual environment or explicitly create virtual environment, I guess we can continue the discussion for sure.

## Testing notes:
1. Launch MD
2. You can manage to open the AYON dialog and access the plugins.
