### PR TITLE
Pre-launch Hook for auto-installing ayon plugin

### DIFF
--- a/client/ayon_marvelousdesigner/hooks/pre_install_ayon_plugins.py
+++ b/client/ayon_marvelousdesigner/hooks/pre_install_ayon_plugins.py
@@ -1,0 +1,69 @@
+"""Pre-launch hook for installing Ayon Plugins in Marvelous Designer.
+
+This module provides:
+InstallQtBinding: Pre-launch hook that installs PySide6 to MD's
+  Python environment to enable Qt-based functionality.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import ClassVar
+
+from ayon_applications import LaunchTypes, PreLaunchHook
+from ayon_marvelousdesigner import (
+    MARVELOUS_DESIGNER_HOST_DIR,
+)
+
+
+class InstallAyonPlugins(PreLaunchHook):
+    """Install AYON plugins to Marvelous Designer's plugins."""
+
+    app_groups: ClassVar = {"marvelousdesigner"}
+    order = 12
+    launch_types: ClassVar = {LaunchTypes.local}
+
+    def execute(self) -> None:
+        """Execute the pre-launch hook to install AYON plugins."""
+        md_setting = self.data["project_settings"]["marvelous_designer"]
+        plugins_dir = md_setting["prelaunch_settings"].get(
+            "plugins_dir", "")
+        plugins_dir = Path(plugins_dir)
+        if not plugins_dir.exists():
+            self.log.warning("Plugins directory not found: %s", plugins_dir)
+            return
+        plugins_json = plugins_dir / "pluginSettings.json"
+        deployed_script = (
+            Path(MARVELOUS_DESIGNER_HOST_DIR)
+            / "deploy" / "ayon_plugins.py"
+        )
+        self._write_plugins_json(
+            plugins_json.as_posix(),
+            deployed_script.as_posix()
+        )
+
+    @staticmethod
+    def _write_plugins_json(plugins_json: str, deployed_script: str) -> None:
+        """Write the AYON plugin settings to a JSON file.
+
+        Args:
+            plugins_json: Path to the plugin settings JSON file.
+            deployed_script: Path to the deployed plugin script to be added.
+        """
+        plugins_data = {
+            "plugins": [
+                {
+                "m_AddingPositionIndex": 1,
+                "m_BaseMenuTreeByObjectName": "Plugins / Plug-in",
+                "m_PlugInFileName": deployed_script,
+                "m_PlugInIconFileName": "",
+                "m_PlugInTitle": "ayon_plugins",
+                "m_SourcePath": deployed_script,
+                "m_SourceType": "script"
+                }
+            ],
+            "version": 2
+        }
+
+        with open(plugins_json, "w", encoding="utf-8") as f:
+            json.dump(plugins_data, f, indent=4)

--- a/client/ayon_marvelousdesigner/hooks/pre_install_ayon_plugins.py
+++ b/client/ayon_marvelousdesigner/hooks/pre_install_ayon_plugins.py
@@ -50,20 +50,39 @@ class InstallAyonPlugins(PreLaunchHook):
             plugins_json: Path to the plugin settings JSON file.
             deployed_script: Path to the deployed plugin script to be added.
         """
-        plugins_data = {
-            "plugins": [
-                {
-                "m_AddingPositionIndex": 1,
-                "m_BaseMenuTreeByObjectName": "Plugins / Plug-in",
-                "m_PlugInFileName": deployed_script,
-                "m_PlugInIconFileName": "",
-                "m_PlugInTitle": "ayon_plugins",
-                "m_SourcePath": deployed_script,
-                "m_SourceType": "script"
-                }
-            ],
-            "version": 2
+        new_plugin = {
+            "m_AddingPositionIndex": 1,
+            "m_BaseMenuTreeByObjectName": "Plugins / Plug-in",
+            "m_PlugInFileName": deployed_script,
+            "m_PlugInIconFileName": "",
+            "m_PlugInTitle": "ayon_plugins",
+            "m_SourcePath": deployed_script,
+            "m_SourceType": "script"
         }
 
+        plugins_path = Path(plugins_json)
+        # Try to read existing data
+        if plugins_path.exists():
+            try:
+                with open(plugins_json, encoding="utf-8") as f:
+                    plugins_data = json.load(f)
+            except (OSError, json.JSONDecodeError):
+                # If reading fails, start fresh
+                plugins_data = {"plugins": [], "version": 2}
+        else:
+            plugins_data = {"plugins": [], "version": 2}
+        # Ensure plugins list exists
+        if "plugins" not in plugins_data:
+            plugins_data["plugins"] = []
+
+        # Check if plugin already exists (avoid duplicates)
+        existing_titles = {
+            existing_plugins.get("m_PlugInTitle")
+            for existing_plugins in plugins_data["plugins"]
+        }
+        if "ayon_plugins" not in existing_titles:
+            plugins_data["plugins"].append(new_plugin)
+
+        # Write the updated data
         with open(plugins_json, "w", encoding="utf-8") as f:
             json.dump(plugins_data, f, indent=4)

--- a/server/settings.py
+++ b/server/settings.py
@@ -74,6 +74,15 @@ class PrelaunchModel(BaseSettingsModel):
         default="",
         title="Qt Binding Directory"
     )
+    plugins_dir: str = SettingsField(
+        default="",
+        title="Plugins Directory",
+        description=(
+            "Directory where the pluginSettings.json file is located. "
+            "This is used to add the AYON plugin to Marvelous Designer's "
+            "plugin system."
+        )
+    )
 
 
 class MarvelousDesignerSettings(BaseSettingsModel):
@@ -95,6 +104,7 @@ class MarvelousDesignerSettings(BaseSettingsModel):
 DEFAULT_MD_VALUES: dict[str, Any] = {
     "prelaunch_settings": {
         "qt_binding_dir": "/Users/Public/Documents/MarvelousDesigner/Configuration/python311/Lib/site-packages",  # noqa: E501
+        "plugins_dir": "/Users/Public/Documents/MarvelousDesigner/Configuration/Plugins",  # noqa: E501
     },
     "publish": {
         "ExtractPointCache": {


### PR DESCRIPTION
## Changelog Description
This PR is to add pre-launch hook for ayon plugin auto-installation regarding to the new enhancement made in Marvelous Designer 2026.x.
Fixes https://github.com/ynput/ayon-marvelous-designer/issues/19

## Additional review information
Build and Install the addon

## Testing notes:
1. Edit `ayon+settings://marvelous_designer/prelaunch_settings/plugins_dir` , e.g. in windows should be `C:\Users\Public\Documents\MarvelousDesigner\Plugins`
2. Remove `pluginSettings.json` from `ayon+settings://marvelous_designer/prelaunch_settings/plugins_dir`
3. Launch Marvelous Designer
4. Addon should be installed as expected.

